### PR TITLE
Changed the package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use the corresponding reporter module instead:
 ## Installation
 
 ```bash
-composer require qase/qase-php-commons
+composer require qase/php-commons
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "qase/qase-php-commons",
+  "name": "qase/php-commons",
   "description": "Library with common classes for Qase PHP reporters",
   "homepage": "https://qase.io",
   "license": "Apache-2.0",


### PR DESCRIPTION
This pull request includes changes to update the package name in the `README.md` and `composer.json` files to reflect the correct namespace.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Updated the installation command to use the correct package name `qase/php-commons`.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R2): Changed the package name from `qase/qase-php-commons` to `qase/php-commons`.