### PR TITLE
docs: add tags configuration for test runs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All configuration options are listed in the table below:
 | Qase test run title                                                                                                        | `testops.run.title`        | `QASE_TESTOPS_RUN_TITLE`        | `Automated run <Current date and time>` | No       | Any string                 |
 | Qase test run description                                                                                                  | `testops.run.description`  | `QASE_TESTOPS_RUN_DESCRIPTION`  | `<Framework name> automated run`        | No       | Any string                 |
 | Qase test run complete                                                                                                     | `testops.run.complete`     | `QASE_TESTOPS_RUN_COMPLETE`     | `True`                                  |          | `True`, `False`            |
+| Qase test run tags | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | undefined                               | No       | Config: array of strings, Env: comma-separated string |
 | Qase test plan ID                                                                                                          | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | undefined                               | No       | Any integer                |
 | Size of batch for sending test results                                                                                     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `200`                                   | No       | Any integer                |
 | Enable defects for failed test cases                                                                                       | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `False`                                 | No       | `True`, `False`            |
@@ -75,7 +76,8 @@ All configuration options are listed in the table below:
     "run": {
       "title": "Regress run",
       "description": "Regress run description",
-      "complete": true
+      "complete": true,
+      "tags": ["tag1", "tag2"]
     },
     "defect": false,
     "project": "<project_code>",


### PR DESCRIPTION
- Updated the README.md to include a new configuration option for test run tags.
- Added example JSON structure demonstrating the usage of tags in test run creation.