### PR TITLE
feat: add configuration management for test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ All configuration options are listed in the table below:
 | Qase test plan ID                                                                                                          | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | undefined                               | No       | Any integer                |
 | Size of batch for sending test results                                                                                     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `200`                                   | No       | Any integer                |
 | Enable defects for failed test cases                                                                                       | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `False`                                 | No       | `True`, `False`            |
+| Configuration values to associate with test run                                                                            | `testops.configurations.values` | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `[]`                                   | No       | Comma-separated key=value pairs |
+| Create configuration groups and values if they don't exist                                                                | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `False`                                 | No       | `True`, `False`            |
 
 ### Example `qase.config.json` config:
 
@@ -81,7 +83,45 @@ All configuration options are listed in the table below:
     "project": "<project_code>",
     "batch": {
       "size": 100
+    },
+    "configurations": {
+      "values": [
+        {
+          "name": "browser",
+          "value": "chrome"
+        },
+        {
+          "name": "version",
+          "value": "latest"
+        },
+        {
+          "name": "environment",
+          "value": "staging"
+        }
+      ],
+      "createIfNotExists": true
     }
   }
 }
 ```
+
+### Environment Variables Example:
+
+You can also configure configurations using environment variables:
+
+```bash
+export QASE_TESTOPS_CONFIGURATIONS_VALUES="browser=chrome,version=latest,environment=staging"
+export QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS=true
+```
+
+The `QASE_TESTOPS_CONFIGURATIONS_VALUES` should be a comma-separated list of key=value pairs.
+
+### How Configurations Work
+
+Configurations in Qase TestOps work as follows:
+- **name** field represents the configuration group (e.g., "browser", "environment")
+- **value** field represents the configuration item within that group (e.g., "chrome", "staging")
+- When `createIfNotExists` is true, the system will:
+  1. Create a configuration group with the specified name if it doesn't exist
+  2. Create a configuration item with the specified value in that group
+  3. Associate the configuration item ID with the test run

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "phpunit"
   },
-  "version": "2.1.1",
+  "version": "2.1.2",
   "config": {
     "platform": {
       "php": "8.0"

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -75,6 +75,13 @@ class ConfigLoader
 
         if (isset($data['testops']['batch']['size'])) $config->testops->batch->setSize($data['testops']['batch']['size']);
 
+        if (isset($data['testops']['configurations']['values'])) {
+            $config->testops->configurations->setValues($data['testops']['configurations']['values']);
+        }
+        if (isset($data['testops']['configurations']['createIfNotExists'])) {
+            $config->testops->configurations->setCreateIfNotExists($data['testops']['configurations']['createIfNotExists']);
+        }
+
         if (isset($data['report']['driver'])) $config->report->setDriver($data['report']['driver']);
 
         if (isset($data['report']['connection']['path'])) $config->report->connection->setPath($data['report']['connection']['path']);
@@ -136,6 +143,12 @@ class ConfigLoader
                 case "qase_testops_batch_size":
                     $this->config->testops->batch->setSize($value);
                     break;
+                case "qase_testops_configurations_values":
+                    $this->parseConfigurationValues($value);
+                    break;
+                case "qase_testops_configurations_create_if_not_exists":
+                    $this->config->testops->configurations->setCreateIfNotExists($value);
+                    break;
                 case "qase_report_driver":
                     $this->config->report->setDriver($value);
                     break;
@@ -147,5 +160,35 @@ class ConfigLoader
                     break;
             }
         }
+    }
+
+    /**
+     * Parse configuration values from comma-separated key=value pairs
+     * 
+     * @param string $value Comma-separated key=value pairs
+     */
+    private function parseConfigurationValues(string $value): void
+    {
+        $pairs = array_map('trim', explode(',', $value));
+        $configurations = [];
+
+        foreach ($pairs as $pair) {
+            if (strpos($pair, '=') === false) {
+                continue;
+            }
+
+            list($name, $configValue) = explode('=', $pair, 2);
+            $name = trim($name);
+            $configValue = trim($configValue);
+
+            if (!empty($name) && !empty($configValue)) {
+                $configurations[] = [
+                    'name' => $name,
+                    'value' => $configValue
+                ];
+            }
+        }
+
+        $this->config->testops->configurations->setValues($configurations);
     }
 }

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Qase\PhpCommons\Interfaces;
 
 use Qase\PhpCommons\Models\Attachment;
+use Qase\PhpCommons\Models\ConfigurationGroup;
+use Qase\PhpCommons\Models\ConfigurationItem;
 
 
 interface ClientInterface
@@ -13,7 +15,7 @@ interface ClientInterface
 
     public function getEnvironment(string $code, string $envName): ?int;
 
-    public function createTestRun(string $code, string $title, ?string $description = null, ?int $planId = null, ?int $envId = null, ?array $tags = null): int;
+    public function createTestRun(string $code, string $title, ?string $description = null, ?int $planId = null, ?int $envId = null, ?array $tags = null, ?array $configurations = null): int;
 
     public function completeTestRun(string $code, int $runId): void;
 
@@ -22,4 +24,31 @@ interface ClientInterface
     public function uploadAttachment(string $code, Attachment $attachment): ?string;
 
     public function sendResults(string $code, int $runId, array $results): void;
+
+    /**
+     * Get configuration groups for a project
+     * 
+     * @param string $code Project code
+     * @return ConfigurationGroup[]
+     */
+    public function getConfigurationGroups(string $code): array;
+
+    /**
+     * Create a configuration group
+     * 
+     * @param string $code Project code
+     * @param string $title Group title
+     * @return ConfigurationGroup|null
+     */
+    public function createConfigurationGroup(string $code, string $title): ?ConfigurationGroup;
+
+    /**
+     * Create a configuration item
+     * 
+     * @param string $code Project code
+     * @param int $groupId Group ID
+     * @param string $title Item title
+     * @return ConfigurationItem|null
+     */
+    public function createConfigurationItem(string $code, int $groupId, string $title): ?ConfigurationItem;
 }

--- a/src/Models/Config/ConfigurationConfig.php
+++ b/src/Models/Config/ConfigurationConfig.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PhpCommons\Models\Config;
+
+class ConfigurationConfig
+{
+    /**
+     * @var array<array{name: string, value: string}> Configuration values to associate with the test run
+     */
+    public array $values = [];
+
+    /**
+     * @var bool Whether to create configuration groups and values if they don't exist
+     */
+    public bool $createIfNotExists = false;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * Get configuration values
+     * 
+     * @return array<array{name: string, value: string}>
+     */
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * Set configuration values
+     * 
+     * @param array<array{name: string, value: string}> $values
+     */
+    public function setValues(array $values): void
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * Add a configuration value
+     * 
+     * @param string $name
+     * @param string $value
+     */
+    public function addValue(string $name, string $value): void
+    {
+        $this->values[] = [
+            'name' => $name,
+            'value' => $value
+        ];
+    }
+
+    /**
+     * Get createIfNotExists flag
+     */
+    public function isCreateIfNotExists(): bool
+    {
+        return $this->createIfNotExists;
+    }
+
+    /**
+     * Set createIfNotExists flag
+     */
+    public function setCreateIfNotExists(bool $createIfNotExists): void
+    {
+        $this->createIfNotExists = $createIfNotExists;
+    }
+} 

--- a/src/Models/Config/TestopsConfig.php
+++ b/src/Models/Config/TestopsConfig.php
@@ -11,6 +11,7 @@ class TestopsConfig
     public RunConfig $run;
     public PlanConfig $plan;
     public Batch $batch;
+    public ConfigurationConfig $configurations;
 
     public function __construct()
     {
@@ -18,6 +19,7 @@ class TestopsConfig
         $this->run = new RunConfig();
         $this->plan = new PlanConfig();
         $this->batch = new Batch();
+        $this->configurations = new ConfigurationConfig();
     }
 
     public function getProject(): ?string

--- a/src/Models/ConfigurationGroup.php
+++ b/src/Models/ConfigurationGroup.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PhpCommons\Models;
+
+class ConfigurationGroup
+{
+    public ?int $id = null;
+    public ?string $title = null;
+    public array $items = [];
+
+    public function __construct(?int $id = null, ?string $title = null)
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->items = [];
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+} 

--- a/src/Models/ConfigurationItem.php
+++ b/src/Models/ConfigurationItem.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PhpCommons\Models;
+
+class ConfigurationItem
+{
+    public ?int $id = null;
+    public ?string $title = null;
+
+    public function __construct(?int $id = null, ?string $title = null)
+    {
+        $this->id = $id;
+        $this->title = $title;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+} 

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PhpCommons\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PhpCommons\Config\ConfigLoader;
+use Qase\PhpCommons\Loggers\Logger;
+
+class ConfigLoaderTest extends TestCase
+{
+    private Logger $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = new Logger();
+    }
+
+    public function testConfigurationValuesFromEnv(): void
+    {
+        // Set environment variables
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES=browser=chrome,version=latest,environment=staging');
+        putenv('QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS=true');
+
+        $configLoader = new ConfigLoader($this->logger);
+        $config = $configLoader->getConfig();
+
+        $this->assertTrue($config->testops->configurations->isCreateIfNotExists());
+        
+        $values = $config->testops->configurations->getValues();
+        $this->assertCount(3, $values);
+        
+        $this->assertEquals('browser', $values[0]['name']);
+        $this->assertEquals('chrome', $values[0]['value']);
+        
+        $this->assertEquals('version', $values[1]['name']);
+        $this->assertEquals('latest', $values[1]['value']);
+        
+        $this->assertEquals('environment', $values[2]['name']);
+        $this->assertEquals('staging', $values[2]['value']);
+
+        // Clean up
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES');
+        putenv('QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS');
+    }
+
+    public function testConfigurationValuesFromEnvWithSpaces(): void
+    {
+        // Set environment variables with spaces
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES=browser=chrome, version=latest , environment=staging');
+
+        $configLoader = new ConfigLoader($this->logger);
+        $config = $configLoader->getConfig();
+
+        $values = $config->testops->configurations->getValues();
+        $this->assertCount(3, $values);
+        
+        $this->assertEquals('browser', $values[0]['name']);
+        $this->assertEquals('chrome', $values[0]['value']);
+        
+        $this->assertEquals('version', $values[1]['name']);
+        $this->assertEquals('latest', $values[1]['value']);
+        
+        $this->assertEquals('environment', $values[2]['name']);
+        $this->assertEquals('staging', $values[2]['value']);
+
+        // Clean up
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES');
+    }
+
+    public function testConfigurationValuesFromEnvInvalidFormat(): void
+    {
+        // Set environment variables with invalid format
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES=invalid_format,another_invalid');
+
+        $configLoader = new ConfigLoader($this->logger);
+        $config = $configLoader->getConfig();
+
+        $values = $config->testops->configurations->getValues();
+        $this->assertEmpty($values);
+
+        // Clean up
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES');
+    }
+
+    public function testConfigurationValuesFromEnvMixedFormat(): void
+    {
+        // Set environment variables with mixed valid and invalid format
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES=invalid,browser=chrome,another_invalid,version=latest');
+
+        $configLoader = new ConfigLoader($this->logger);
+        $config = $configLoader->getConfig();
+
+        $values = $config->testops->configurations->getValues();
+        $this->assertCount(2, $values);
+        
+        $this->assertEquals('browser', $values[0]['name']);
+        $this->assertEquals('chrome', $values[0]['value']);
+        
+        $this->assertEquals('version', $values[1]['name']);
+        $this->assertEquals('latest', $values[1]['value']);
+
+        // Clean up
+        putenv('QASE_TESTOPS_CONFIGURATIONS_VALUES');
+    }
+} 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PhpCommons\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PhpCommons\Models\Config\ConfigurationConfig;
+use Qase\PhpCommons\Models\ConfigurationGroup;
+use Qase\PhpCommons\Models\ConfigurationItem;
+
+class ConfigurationTest extends TestCase
+{
+    public function testConfigurationConfigCreation(): void
+    {
+        $config = new ConfigurationConfig();
+        
+        $this->assertInstanceOf(ConfigurationConfig::class, $config);
+        $this->assertEmpty($config->getValues());
+        $this->assertFalse($config->isCreateIfNotExists());
+    }
+
+    public function testConfigurationConfigValues(): void
+    {
+        $config = new ConfigurationConfig();
+        
+        $values = [
+            [
+                'name' => 'browser',
+                'value' => 'chrome'
+            ],
+            [
+                'name' => 'version',
+                'value' => 'latest'
+            ],
+            [
+                'name' => 'environment',
+                'value' => 'staging'
+            ]
+        ];
+        
+        $config->setValues($values);
+        $this->assertEquals($values, $config->getValues());
+        
+        $config->addValue('platform', 'linux');
+        $this->assertCount(4, $config->getValues());
+        $this->assertEquals('platform', $config->getValues()[3]['name']);
+        $this->assertEquals('linux', $config->getValues()[3]['value']);
+    }
+
+    public function testConfigurationConfigCreateIfNotExists(): void
+    {
+        $config = new ConfigurationConfig();
+        
+        $config->setCreateIfNotExists(true);
+        $this->assertTrue($config->isCreateIfNotExists());
+        
+        $config->setCreateIfNotExists(false);
+        $this->assertFalse($config->isCreateIfNotExists());
+    }
+
+    public function testConfigurationGroupCreation(): void
+    {
+        $group = new ConfigurationGroup(1, 'Test Group');
+        
+        $this->assertInstanceOf(ConfigurationGroup::class, $group);
+        $this->assertEquals(1, $group->getId());
+        $this->assertEquals('Test Group', $group->getTitle());
+    }
+
+    public function testConfigurationGroupSetters(): void
+    {
+        $group = new ConfigurationGroup();
+        
+        $group->setId(2);
+        $group->setTitle('New Title');
+        
+        $this->assertEquals(2, $group->getId());
+        $this->assertEquals('New Title', $group->getTitle());
+    }
+
+    public function testConfigurationItemCreation(): void
+    {
+        $item = new ConfigurationItem(1, 'Test Item');
+        
+        $this->assertInstanceOf(ConfigurationItem::class, $item);
+        $this->assertEquals(1, $item->getId());
+        $this->assertEquals('Test Item', $item->getTitle());
+    }
+
+    public function testConfigurationItemSetters(): void
+    {
+        $item = new ConfigurationItem();
+        
+        $item->setId(2);
+        $item->setTitle('New Item');
+        
+        $this->assertEquals(2, $item->getId());
+        $this->assertEquals('New Item', $item->getTitle());
+    }
+} 


### PR DESCRIPTION
- Incremented project version to `2.1.2` in `composer.json`.
- Introduced configuration management for test runs, allowing users to associate key-value pairs with runs.
- Added methods for creating and retrieving configuration groups and items in the `ApiClientV1`.
- Enhanced `ConfigLoader` to support loading configuration values from environment variables.
- Implemented tests for configuration loading and management functionality.