### PR TITLE
Update PHPUnit and ramsey uuid requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
     "php": "^8.0",
     "qase/qase-api-client": "^1.1.0",
     "qase/qase-api-v2-client": "^1.1.0",
-    "ramsey/uuid": "4.7.*"
+    "ramsey/uuid": "^4.7"
   },
   "require-dev": {
     "ext-json": "*",
-    "phpunit/phpunit": "^9"
+    "phpunit/phpunit": "^9 || ^10 || ^11"
   },
   "scripts": {
     "test": "phpunit"


### PR DESCRIPTION
Hey there,

I am getting conflicts installing the qase/phpunit package in our project.
We are using `phpunit 10` and `PHP 8.2` and `ramsey/uuid 4.8.x`.

There shouldn't be an issue for this package