### PR TITLE
feat: implement status mapping for test results

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "phpunit"
   },
-  "version": "2.1.4",
+  "version": "2.1.5",
   "config": {
     "platform": {
       "php": "8.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cddb601bffdaf562f18027f6972fc8fb",
+    "content-hash": "fb9ffcd7a86a1d38213bc2bfc74faeac",
     "packages": [
         {
             "name": "brick/math",
@@ -548,16 +548,16 @@
         },
         {
             "name": "qase/qase-api-client",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-client.git",
-                "reference": "148114f7fecbc8aa5bd80c9afa924594aba9aa72"
+                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/148114f7fecbc8aa5bd80c9afa924594aba9aa72",
-                "reference": "148114f7fecbc8aa5bd80c9afa924594aba9aa72",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
+                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
                 "shasum": ""
             },
             "require": {
@@ -598,9 +598,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.4"
+                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.5"
             },
-            "time": "2025-08-13T10:54:39+00:00"
+            "time": "2025-09-23T12:19:27+00:00"
         },
         {
             "name": "qase/qase-api-v2-client",
@@ -1646,16 +1646,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.25",
+            "version": "9.6.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "049c011e01be805202d8eebedef49f769a8ec7b7"
+                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/049c011e01be805202d8eebedef49f769a8ec7b7",
-                "reference": "049c011e01be805202d8eebedef49f769a8ec7b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
                 "shasum": ""
             },
             "require": {
@@ -1680,7 +1680,7 @@
                 "sebastian/comparator": "^4.0.9",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
+                "sebastian/exporter": "^4.0.8",
                 "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
@@ -1729,7 +1729,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
             },
             "funding": [
                 {
@@ -1753,7 +1753,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T14:38:31+00:00"
+            "time": "2025-09-24T06:29:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2196,16 +2196,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
@@ -2261,15 +2261,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",

--- a/src/Client/ApiClientV1.php
+++ b/src/Client/ApiClientV1.php
@@ -313,7 +313,7 @@ class ApiClientV1 implements ClientInterface
             $this->logger->debug('Update external issue for project: ' . $code . ', type: ' . $type);
 
             // Map our enum values to API enum values
-            $apiType = $type === 'jiraCloud' ? RunexternalIssues::TYPE_CLOUD : RunexternalIssues::TYPE_SERVER;
+            $apiType = $type === 'jiraCloud' ? RunexternalIssues::TYPE_JIRA_CLOUD : RunexternalIssues::TYPE_JIRA_SERVER;
 
             // Create links array using API models
             $apiLinks = [];

--- a/src/Models/Config/QaseConfig.php
+++ b/src/Models/Config/QaseConfig.php
@@ -12,6 +12,7 @@ class QaseConfig
     public ?string $environment = null;
     public ?string $rootSuite = null;
     public bool $debug;
+    public array $statusMapping = [];
     public TestopsConfig $testops;
     public ReportConfig $report;
 
@@ -76,5 +77,25 @@ class QaseConfig
     public function setDebug(bool $debug): void
     {
         $this->debug = $debug;
+    }
+
+    /**
+     * Get status mapping configuration
+     * 
+     * @return array<string, string>
+     */
+    public function getStatusMapping(): array
+    {
+        return $this->statusMapping;
+    }
+
+    /**
+     * Set status mapping configuration
+     * 
+     * @param array<string, string> $statusMapping
+     */
+    public function setStatusMapping(array $statusMapping): void
+    {
+        $this->statusMapping = $statusMapping;
     }
 }

--- a/src/Reporters/ReporterFactory.php
+++ b/src/Reporters/ReporterFactory.php
@@ -14,6 +14,7 @@ use Qase\PhpCommons\Loggers\Logger;
 use Qase\PhpCommons\Models\Config\QaseConfig;
 use Qase\PhpCommons\Utils\HostInfo;
 use Qase\PhpCommons\Utils\StateManager;
+use Qase\PhpCommons\Utils\StatusMapping;
 
 class ReporterFactory
 {
@@ -29,7 +30,11 @@ class ReporterFactory
         $reporter = self::createInternalReporter($logger, $config, $state);
         $fallbackReporter = self::createInternalReporter($logger, $config, $state, true);
 
-        return new CoreReporter($logger, $reporter, $fallbackReporter, $config->getRootSuite());
+        // Create status mapping utility
+        $statusMapping = new StatusMapping($logger);
+        $statusMapping->setMapping($config->getStatusMapping());
+
+        return new CoreReporter($logger, $reporter, $fallbackReporter, $config->getRootSuite(), $statusMapping);
     }
 
     private static function createInternalReporter(LoggerInterface $logger, QaseConfig $config, StateInterface $state, bool $fallback = false): ?InternalReporterInterface

--- a/src/Utils/StatusMapping.php
+++ b/src/Utils/StatusMapping.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PhpCommons\Utils;
+
+use Qase\PhpCommons\Interfaces\LoggerInterface;
+
+/**
+ * Utility class for mapping test result statuses
+ */
+class StatusMapping
+{
+    /**
+     * Valid statuses that can be mapped
+     */
+    public const VALID_STATUSES = [
+        'passed',
+        'failed', 
+        'skipped',
+        'blocked',
+        'invalid'
+    ];
+
+    /**
+     * @var array<string, string> Status mapping configuration
+     */
+    private array $mapping = [];
+
+    /**
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Set status mapping from array
+     * 
+     * @param array<string, string> $mapping
+     */
+    public function setMapping(array $mapping): void
+    {
+        $this->mapping = $this->validateMapping($mapping);
+    }
+
+    /**
+     * Parse status mapping from environment variable format
+     * Format: "invalid=failed,skipped=passed"
+     * 
+     * @param string $envValue
+     */
+    public function parseFromEnv(string $envValue): void
+    {
+        if (empty(trim($envValue))) {
+            $this->mapping = [];
+            return;
+        }
+
+        $mapping = [];
+        $pairs = array_map('trim', explode(',', $envValue));
+
+        foreach ($pairs as $pair) {
+            if (strpos($pair, '=') === false) {
+                $this->logger->error("Invalid status mapping pair format: '$pair'. Expected format: 'source=target'");
+                continue;
+            }
+
+            list($source, $target) = explode('=', $pair, 2);
+            $source = trim($source);
+            $target = trim($target);
+
+            if (!empty($source) && !empty($target)) {
+                $mapping[$source] = $target;
+            }
+        }
+
+        $this->mapping = $this->validateMapping($mapping);
+    }
+
+    /**
+     * Apply status mapping to a status
+     * 
+     * @param string $status Original status
+     * @return string Mapped status or original if no mapping exists
+     */
+    public function mapStatus(string $status): string
+    {
+        if (isset($this->mapping[$status])) {
+            $mappedStatus = $this->mapping[$status];
+            $this->logger->debug("Status mapping applied: '$status' -> '$mappedStatus'");
+            return $mappedStatus;
+        }
+
+        return $status;
+    }
+
+    /**
+     * Get current mapping configuration
+     * 
+     * @return array<string, string>
+     */
+    public function getMapping(): array
+    {
+        return $this->mapping;
+    }
+
+    /**
+     * Check if mapping is empty
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->mapping);
+    }
+
+    /**
+     * Validate mapping configuration
+     * 
+     * @param array<string, string> $mapping
+     * @return array<string, string> Validated mapping
+     */
+    private function validateMapping(array $mapping): array
+    {
+        $validatedMapping = [];
+
+        foreach ($mapping as $source => $target) {
+            if (!is_string($source) || !is_string($target)) {
+                $this->logger->error("Status mapping keys and values must be strings. Skipping: '$source' => '$target'");
+                continue;
+            }
+
+            if (!in_array($source, self::VALID_STATUSES, true)) {
+                $this->logger->error("Invalid source status '$source' in mapping. Valid statuses: " . implode(', ', self::VALID_STATUSES));
+                continue;
+            }
+
+            if (!in_array($target, self::VALID_STATUSES, true)) {
+                $this->logger->error("Invalid target status '$target' in mapping. Valid statuses: " . implode(', ', self::VALID_STATUSES));
+                continue;
+            }
+
+            if ($source === $target) {
+                $this->logger->error("Redundant mapping: '$source' => '$target'. Source and target are the same.");
+                continue;
+            }
+
+            $validatedMapping[$source] = $target;
+        }
+
+        return $validatedMapping;
+    }
+
+    /**
+     * Get all valid statuses
+     * 
+     * @return array<string>
+     */
+    public static function getValidStatuses(): array
+    {
+        return self::VALID_STATUSES;
+    }
+
+    /**
+     * Check if a status is valid
+     * 
+     * @param string $status
+     * @return bool
+     */
+    public static function isValidStatus(string $status): bool
+    {
+        return in_array($status, self::VALID_STATUSES, true);
+    }
+}

--- a/tests/ConfigLoaderStatusMappingTest.php
+++ b/tests/ConfigLoaderStatusMappingTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PhpCommons\Config\ConfigLoader;
+use Qase\PhpCommons\Loggers\Logger;
+
+class ConfigLoaderStatusMappingTest extends TestCase
+{
+    private Logger $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = new Logger(false);
+    }
+
+    public function testLoadStatusMappingFromJson(): void
+    {
+        // Create temporary config file
+        $configData = [
+            'mode' => 'off',
+            'statusMapping' => [
+                'invalid' => 'failed',
+                'skipped' => 'passed'
+            ]
+        ];
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'qase_config_');
+        file_put_contents($tempFile, json_encode($configData));
+        
+        // Change working directory to temp directory
+        $originalCwd = getcwd();
+        chdir(dirname($tempFile));
+        
+        // Rename temp file to qase.config.json
+        $configPath = dirname($tempFile) . '/qase.config.json';
+        rename($tempFile, $configPath);
+        
+        try {
+            $configLoader = new ConfigLoader($this->logger);
+            $config = $configLoader->getConfig();
+            
+            $expectedMapping = [
+                'invalid' => 'failed',
+                'skipped' => 'passed'
+            ];
+            
+            $this->assertEquals($expectedMapping, $config->getStatusMapping());
+        } finally {
+            chdir($originalCwd);
+            if (file_exists($configPath)) {
+                unlink($configPath);
+            }
+        }
+    }
+
+    public function testLoadStatusMappingFromEnv(): void
+    {
+        // Set environment variable
+        putenv('QASE_STATUS_MAPPING=invalid=failed,skipped=passed');
+        
+        try {
+            $configLoader = new ConfigLoader($this->logger);
+            $config = $configLoader->getConfig();
+            
+            $expectedMapping = [
+                'invalid' => 'failed',
+                'skipped' => 'passed'
+            ];
+            
+            $this->assertEquals($expectedMapping, $config->getStatusMapping());
+        } finally {
+            putenv('QASE_STATUS_MAPPING');
+        }
+    }
+
+    public function testEnvOverridesJson(): void
+    {
+        // Create temporary config file
+        $configData = [
+            'mode' => 'off',
+            'statusMapping' => [
+                'invalid' => 'blocked'
+            ]
+        ];
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'qase_config_');
+        file_put_contents($tempFile, json_encode($configData));
+        
+        // Change working directory to temp directory
+        $originalCwd = getcwd();
+        chdir(dirname($tempFile));
+        
+        // Set environment variable
+        putenv('QASE_STATUS_MAPPING=invalid=failed,skipped=passed');
+        
+        try {
+            $configLoader = new ConfigLoader($this->logger);
+            $config = $configLoader->getConfig();
+            
+            // Environment should override JSON
+            $expectedMapping = [
+                'invalid' => 'failed',
+                'skipped' => 'passed'
+            ];
+            
+            $this->assertEquals($expectedMapping, $config->getStatusMapping());
+        } finally {
+            chdir($originalCwd);
+            unlink($tempFile);
+            putenv('QASE_STATUS_MAPPING');
+        }
+    }
+
+    public function testEmptyStatusMapping(): void
+    {
+        $configLoader = new ConfigLoader($this->logger);
+        $config = $configLoader->getConfig();
+        
+        $this->assertEmpty($config->getStatusMapping());
+    }
+
+    public function testInvalidStatusMappingInJson(): void
+    {
+        // Create temporary config file with invalid mapping
+        $configData = [
+            'mode' => 'off',
+            'statusMapping' => [
+                'invalid' => 'failed',
+                'unknown' => 'passed', // invalid source
+                'skipped' => 'unknown' // invalid target
+            ]
+        ];
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'qase_config_');
+        file_put_contents($tempFile, json_encode($configData));
+        
+        // Change working directory to temp directory
+        $originalCwd = getcwd();
+        chdir(dirname($tempFile));
+        
+        // Rename temp file to qase.config.json
+        $configPath = dirname($tempFile) . '/qase.config.json';
+        rename($tempFile, $configPath);
+        
+        try {
+            $configLoader = new ConfigLoader($this->logger);
+            $config = $configLoader->getConfig();
+            
+            // Only valid mappings should be kept
+            $expectedMapping = ['invalid' => 'failed'];
+            $this->assertEquals($expectedMapping, $config->getStatusMapping());
+        } finally {
+            chdir($originalCwd);
+            if (file_exists($configPath)) {
+                unlink($configPath);
+            }
+        }
+    }
+
+    public function testInvalidStatusMappingInEnv(): void
+    {
+        // Set environment variable with invalid mapping
+        putenv('QASE_STATUS_MAPPING=invalid=failed,unknown=passed,skipped=unknown');
+        
+        try {
+            $configLoader = new ConfigLoader($this->logger);
+            $config = $configLoader->getConfig();
+            
+            // Only valid mappings should be kept
+            $expectedMapping = ['invalid' => 'failed'];
+            $this->assertEquals($expectedMapping, $config->getStatusMapping());
+        } finally {
+            putenv('QASE_STATUS_MAPPING');
+        }
+    }
+}

--- a/tests/CoreReporterStatusMappingTest.php
+++ b/tests/CoreReporterStatusMappingTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PhpCommons\Interfaces\InternalReporterInterface;
+use Qase\PhpCommons\Interfaces\LoggerInterface;
+use Qase\PhpCommons\Loggers\Logger;
+use Qase\PhpCommons\Models\Result;
+use Qase\PhpCommons\Models\ResultExecution;
+use Qase\PhpCommons\Models\Step;
+use Qase\PhpCommons\Models\StepExecution;
+use Qase\PhpCommons\Reporters\CoreReporter;
+use Qase\PhpCommons\Utils\StatusMapping;
+
+class CoreReporterStatusMappingTest extends TestCase
+{
+    private Logger $logger;
+    private StatusMapping $statusMapping;
+    private MockInternalReporter $mockReporter;
+    private CoreReporter $coreReporter;
+
+    protected function setUp(): void
+    {
+        $this->logger = new Logger(false);
+        $this->statusMapping = new StatusMapping($this->logger);
+        $this->mockReporter = new MockInternalReporter();
+        $this->coreReporter = new CoreReporter(
+            $this->logger,
+            $this->mockReporter,
+            null,
+            null,
+            $this->statusMapping
+        );
+    }
+
+    public function testStatusMappingAppliedToResultExecution(): void
+    {
+        // Set up mapping
+        $this->statusMapping->setMapping(['invalid' => 'failed']);
+        
+        // Create test result
+        $result = new Result();
+        $result->title = 'Test Result';
+        $result->execution = new ResultExecution('invalid');
+        
+        // Add result
+        $this->coreReporter->addResult($result);
+        
+        // Check that status was mapped
+        $this->assertEquals('failed', $result->execution->status);
+    }
+
+    public function testStatusMappingAppliedToSteps(): void
+    {
+        // Set up mapping
+        $this->statusMapping->setMapping(['skipped' => 'passed']);
+        
+        // Create test result with steps
+        $result = new Result();
+        $result->title = 'Test Result';
+        $result->execution = new ResultExecution('passed');
+        
+        // Add steps
+        $step1 = new Step();
+        $step1->title = 'Step 1';
+        $step1->status = 'skipped';
+        
+        $step2 = new Step();
+        $step2->title = 'Step 2';
+        $step2->status = 'passed';
+        
+        $result->steps = [$step1, $step2];
+        
+        // Add result
+        $this->coreReporter->addResult($result);
+        
+        // Check that step statuses were mapped
+        $this->assertEquals('passed', $step1->status);
+        $this->assertEquals('passed', $step2->status); // unchanged
+    }
+
+    public function testNoMappingWhenEmpty(): void
+    {
+        // No mapping set
+        
+        // Create test result
+        $result = new Result();
+        $result->title = 'Test Result';
+        $result->execution = new ResultExecution('invalid');
+        
+        // Add result
+        $this->coreReporter->addResult($result);
+        
+        // Check that status was not changed
+        $this->assertEquals('invalid', $result->execution->status);
+    }
+
+    public function testMultipleMappings(): void
+    {
+        // Set up multiple mappings
+        $this->statusMapping->setMapping([
+            'invalid' => 'failed',
+            'skipped' => 'passed'
+        ]);
+        
+        // Create test result
+        $result = new Result();
+        $result->title = 'Test Result';
+        $result->execution = new ResultExecution('invalid');
+        
+        // Add steps
+        $step1 = new Step();
+        $step1->title = 'Step 1';
+        $step1->status = 'skipped';
+        
+        $step2 = new Step();
+        $step2->title = 'Step 2';
+        $step2->status = 'blocked';
+        
+        $result->steps = [$step1, $step2];
+        
+        // Add result
+        $this->coreReporter->addResult($result);
+        
+        // Check mappings
+        $this->assertEquals('failed', $result->execution->status);
+        $this->assertEquals('passed', $step1->status);
+        $this->assertEquals('blocked', $step2->status); // no mapping
+    }
+
+    public function testResultAddedToReporter(): void
+    {
+        $result = new Result();
+        $result->title = 'Test Result';
+        $result->execution = new ResultExecution('passed');
+        
+        $this->coreReporter->addResult($result);
+        
+        // Check that result was added to mock reporter
+        $this->assertCount(1, $this->mockReporter->getResults());
+        $this->assertEquals($result, $this->mockReporter->getResults()[0]);
+    }
+}
+
+/**
+ * Mock internal reporter for testing
+ */
+class MockInternalReporter implements InternalReporterInterface
+{
+    private array $results = [];
+
+    public function startRun(): void
+    {
+        // Mock implementation
+    }
+
+    public function completeRun(): void
+    {
+        // Mock implementation
+    }
+
+    public function addResult($result): void
+    {
+        $this->results[] = $result;
+    }
+
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function setResults(array $results): void
+    {
+        $this->results = $results;
+    }
+
+    public function sendResults(): void
+    {
+        // Mock implementation
+    }
+}

--- a/tests/CoreReporterTest.php
+++ b/tests/CoreReporterTest.php
@@ -7,6 +7,7 @@ use Qase\PhpCommons\Interfaces\InternalReporterInterface;
 use Qase\PhpCommons\Interfaces\LoggerInterface;
 use Qase\PhpCommons\Models\Result;
 use Qase\PhpCommons\Reporters\CoreReporter;
+use Qase\PhpCommons\Utils\StatusMapping;
 use Exception;
 
 class CoreReporterTest extends TestCase
@@ -22,14 +23,21 @@ class CoreReporterTest extends TestCase
         $this->fallbackReporterMock = $this->createMock(InternalReporterInterface::class);
     }
 
+    private function createCoreReporter(?InternalReporterInterface $primaryReporter = null, ?InternalReporterInterface $fallbackReporter = null, ?string $rootSuite = null): CoreReporter
+    {
+        $statusMapping = new StatusMapping($this->loggerMock);
+        return new CoreReporter(
+            $this->loggerMock,
+            $primaryReporter ?? $this->primaryReporterMock,
+            $fallbackReporter ?? $this->fallbackReporterMock,
+            $rootSuite,
+            $statusMapping
+        );
+    }
+
     public function testStartRunExecutesWithoutException(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         $this->primaryReporterMock->expects($this->once())
             ->method('startRun');
@@ -39,12 +47,7 @@ class CoreReporterTest extends TestCase
 
     public function testStartRunFallbackOnException(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         // Mock primary reporter to throw an exception
         $this->primaryReporterMock->expects($this->once())
@@ -61,12 +64,7 @@ class CoreReporterTest extends TestCase
 
     public function testCompleteRunExecutesWithoutException(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         $this->primaryReporterMock->expects($this->once())
             ->method('completeRun');
@@ -76,12 +74,7 @@ class CoreReporterTest extends TestCase
 
     public function testCompleteRunFallbackOnException(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         $this->primaryReporterMock->expects($this->once())
             ->method('completeRun')
@@ -97,12 +90,7 @@ class CoreReporterTest extends TestCase
     {
         $result = new Result();
 
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         $this->primaryReporterMock->expects($this->once())
             ->method('addResult')
@@ -113,12 +101,7 @@ class CoreReporterTest extends TestCase
 
     public function testAddResultFallbackOnException(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         $this->primaryReporterMock->expects($this->once())
             ->method('addResult')
@@ -132,12 +115,7 @@ class CoreReporterTest extends TestCase
 
     public function testRunFallbackReporterWhenPrimaryReporterFails(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         // Mock failure of primary reporter
         $this->primaryReporterMock->expects($this->once())
@@ -154,12 +132,7 @@ class CoreReporterTest extends TestCase
 
     public function testRunFallbackReporterWhenFallbackFails(): void
     {
-        $coreReporter = new CoreReporter(
-            $this->loggerMock,
-            $this->primaryReporterMock,
-            $this->fallbackReporterMock,
-            null
-        );
+        $coreReporter = $this->createCoreReporter();
 
         // Simulate primary reporter running, but fallback reporter fails
         $this->primaryReporterMock->expects($this->once())

--- a/tests/ExternalLinkApiTest.php
+++ b/tests/ExternalLinkApiTest.php
@@ -50,8 +50,8 @@ class ExternalLinkApiTest extends TestCase
     public function testApiModelConstants(): void
     {
         // Test that the API model constants are correct
-        $this->assertEquals('jira-cloud', RunexternalIssues::TYPE_CLOUD);
-        $this->assertEquals('jira-server', RunexternalIssues::TYPE_SERVER);
+        $this->assertEquals('jira-cloud', RunexternalIssues::TYPE_JIRA_CLOUD);
+        $this->assertEquals('jira-server', RunexternalIssues::TYPE_JIRA_SERVER);
     }
 
     public function testApiModelCreation(): void
@@ -65,10 +65,10 @@ class ExternalLinkApiTest extends TestCase
         $this->assertEquals('PROJ-123', $link->getExternalIssue());
         
         $externalIssues = new RunexternalIssues();
-        $externalIssues->setType(RunexternalIssues::TYPE_CLOUD);
+        $externalIssues->setType(RunexternalIssues::TYPE_JIRA_CLOUD);
         $externalIssues->setLinks([$link]);
         
-        $this->assertEquals(RunexternalIssues::TYPE_CLOUD, $externalIssues->getType());
+        $this->assertEquals(RunexternalIssues::TYPE_JIRA_CLOUD, $externalIssues->getType());
         $this->assertCount(1, $externalIssues->getLinks());
     }
 }

--- a/tests/StatusMappingTest.php
+++ b/tests/StatusMappingTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PhpCommons\Loggers\Logger;
+use Qase\PhpCommons\Utils\StatusMapping;
+
+class StatusMappingTest extends TestCase
+{
+    private Logger $logger;
+    private StatusMapping $statusMapping;
+
+    protected function setUp(): void
+    {
+        $this->logger = new Logger(false);
+        $this->statusMapping = new StatusMapping($this->logger);
+    }
+
+    public function testValidStatuses(): void
+    {
+        $validStatuses = StatusMapping::getValidStatuses();
+        $expectedStatuses = ['passed', 'failed', 'skipped', 'blocked', 'invalid'];
+        
+        $this->assertEquals($expectedStatuses, $validStatuses);
+    }
+
+    public function testIsValidStatus(): void
+    {
+        $this->assertTrue(StatusMapping::isValidStatus('passed'));
+        $this->assertTrue(StatusMapping::isValidStatus('failed'));
+        $this->assertTrue(StatusMapping::isValidStatus('skipped'));
+        $this->assertTrue(StatusMapping::isValidStatus('blocked'));
+        $this->assertTrue(StatusMapping::isValidStatus('invalid'));
+        
+        $this->assertFalse(StatusMapping::isValidStatus('unknown'));
+        $this->assertFalse(StatusMapping::isValidStatus(''));
+        $this->assertFalse(StatusMapping::isValidStatus('PASSED')); // case sensitive
+    }
+
+    public function testSetValidMapping(): void
+    {
+        $mapping = [
+            'invalid' => 'failed',
+            'skipped' => 'passed'
+        ];
+        
+        $this->statusMapping->setMapping($mapping);
+        
+        $this->assertEquals($mapping, $this->statusMapping->getMapping());
+        $this->assertFalse($this->statusMapping->isEmpty());
+    }
+
+    public function testSetInvalidMapping(): void
+    {
+        $mapping = [
+            'invalid' => 'failed',
+            'unknown' => 'passed', // invalid source
+            'skipped' => 'unknown', // invalid target
+            'passed' => 'passed' // redundant mapping
+        ];
+        
+        $this->statusMapping->setMapping($mapping);
+        
+        // Only valid mappings should be kept
+        $expectedMapping = ['invalid' => 'failed'];
+        $this->assertEquals($expectedMapping, $this->statusMapping->getMapping());
+    }
+
+    public function testMapStatus(): void
+    {
+        $mapping = [
+            'invalid' => 'failed',
+            'skipped' => 'passed'
+        ];
+        
+        $this->statusMapping->setMapping($mapping);
+        
+        $this->assertEquals('failed', $this->statusMapping->mapStatus('invalid'));
+        $this->assertEquals('passed', $this->statusMapping->mapStatus('skipped'));
+        $this->assertEquals('blocked', $this->statusMapping->mapStatus('blocked')); // no mapping
+        $this->assertEquals('unknown', $this->statusMapping->mapStatus('unknown')); // invalid status
+    }
+
+    public function testParseFromEnvValid(): void
+    {
+        $envValue = 'invalid=failed,skipped=passed';
+        $this->statusMapping->parseFromEnv($envValue);
+        
+        $expectedMapping = [
+            'invalid' => 'failed',
+            'skipped' => 'passed'
+        ];
+        
+        $this->assertEquals($expectedMapping, $this->statusMapping->getMapping());
+    }
+
+    public function testParseFromEnvInvalid(): void
+    {
+        $envValue = 'invalid=failed,invalid-pair,skipped=passed';
+        $this->statusMapping->parseFromEnv($envValue);
+        
+        $expectedMapping = [
+            'invalid' => 'failed',
+            'skipped' => 'passed'
+        ];
+        
+        $this->assertEquals($expectedMapping, $this->statusMapping->getMapping());
+    }
+
+    public function testParseFromEnvEmpty(): void
+    {
+        $this->statusMapping->parseFromEnv('');
+        $this->assertTrue($this->statusMapping->isEmpty());
+        
+        $this->statusMapping->parseFromEnv('   ');
+        $this->assertTrue($this->statusMapping->isEmpty());
+    }
+
+    public function testParseFromEnvWithSpaces(): void
+    {
+        $envValue = ' invalid = failed , skipped = passed ';
+        $this->statusMapping->parseFromEnv($envValue);
+        
+        $expectedMapping = [
+            'invalid' => 'failed',
+            'skipped' => 'passed'
+        ];
+        
+        $this->assertEquals($expectedMapping, $this->statusMapping->getMapping());
+    }
+
+    public function testIsEmpty(): void
+    {
+        $this->assertTrue($this->statusMapping->isEmpty());
+        
+        $this->statusMapping->setMapping(['invalid' => 'failed']);
+        $this->assertFalse($this->statusMapping->isEmpty());
+        
+        $this->statusMapping->setMapping([]);
+        $this->assertTrue($this->statusMapping->isEmpty());
+    }
+
+    public function testNonStringMappingValues(): void
+    {
+        $mapping = [
+            'invalid' => 'failed',
+            123 => 'passed', // non-string key
+            'skipped' => 456 // non-string value
+        ];
+        
+        $this->statusMapping->setMapping($mapping);
+        
+        // Only valid string mappings should be kept
+        $expectedMapping = ['invalid' => 'failed'];
+        $this->assertEquals($expectedMapping, $this->statusMapping->getMapping());
+    }
+
+    public function testCaseSensitiveMapping(): void
+    {
+        $mapping = [
+            'INVALID' => 'failed', // uppercase source
+            'skipped' => 'PASSED' // uppercase target
+        ];
+        
+        $this->statusMapping->setMapping($mapping);
+        
+        // Case-sensitive validation should reject these
+        $this->assertTrue($this->statusMapping->isEmpty());
+    }
+}


### PR DESCRIPTION
- Added a new `StatusMapping` utility class to handle mapping of test result statuses.
- Enhanced `ConfigLoader` to support loading status mapping from configuration files and environment variables.
- Updated `CoreReporter` to apply status mapping before processing test results.
- Modified `QaseConfig` to include status mapping configuration.
- Added unit tests for status mapping functionality, including validation and parsing from environment variables.
- Updated `README.md` to document the new status mapping feature and provide usage examples.