### PR TITLE
fix: align ResultSpecSerializer and Attachment with JSON Schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "phpunit"
   },
-  "version": "2.1.16",
+  "version": "2.1.17",
   "config": {
     "platform": {
       "php": "8.0"

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Qase\PhpCommons\Models;
 
+use Ramsey\Uuid\Uuid;
 
 final class Attachment extends BaseModel
 {
+    public string $id;
     public ?string $title;
     public ?string $mime;
     public ?string $content;
@@ -14,6 +16,7 @@ final class Attachment extends BaseModel
 
     private function __construct(?string $title = null, ?string $content = null, ?string $mime = null, ?string $path = null)
     {
+        $this->id = Uuid::uuid4()->toString();
         $this->title = $title;
         $this->content = $content;
         $this->mime = $mime;

--- a/src/Reporters/ResultSpecSerializer.php
+++ b/src/Reporters/ResultSpecSerializer.php
@@ -45,14 +45,20 @@ class ResultSpecSerializer
 
     private function normalizeParams(array $params): array
     {
-        return array_map(function ($item) {
-            $name = is_array($item) ? ($item['name'] ?? '') : ($item->name ?? '');
-            $value = is_array($item) ? ($item['value'] ?? null) : ($item->value ?? null);
-            return [
-                'name' => $name,
-                'value' => ($value === null || $value === '') ? 'empty' : $value,
-            ];
-        }, $params);
+        $result = [];
+        foreach ($params as $key => $item) {
+            if (is_string($item) || is_numeric($item) || is_bool($item)) {
+                $value = (string)$item;
+                $result[$key] = ($value === '') ? 'empty' : $value;
+            } elseif (is_array($item)) {
+                $result[$key] = ($item['value'] ?? null) === null || ($item['value'] ?? null) === ''
+                    ? 'empty'
+                    : (string)$item['value'];
+            } else {
+                $result[$key] = 'empty';
+            }
+        }
+        return $result;
     }
 
     private function normalizeParamGroups(array $paramGroups): array
@@ -92,7 +98,7 @@ class ResultSpecSerializer
                 'file_path' => $attachment->path,
                 'mime_type' => $attachment->mime,
                 'size' => null,
-                'id' => null,
+                'id' => $attachment->id,
             ];
         }
         if (is_array($attachment)) {

--- a/tests/ResultSpecSerializerTest.php
+++ b/tests/ResultSpecSerializerTest.php
@@ -131,20 +131,36 @@ class ResultSpecSerializerTest extends TestCase
         $this->assertInstanceOf(\stdClass::class, $data['params']);
     }
 
-    public function testParamsWithEmptyValueBecomeEmptyString(): void
+    public function testParamsAssociativeStringValues(): void
     {
         $result = new Result();
         $result->id = 'r1';
         $result->title = 'T';
         $result->params = [
-            ['name' => 'a', 'value' => 'x'],
-            ['name' => 'b', 'value' => null],
-            ['name' => 'c', 'value' => ''],
+            'version' => 'v1',
+            'empty_param' => '',
+            'number' => 42,
         ];
 
         $data = $this->serializer->toSpecArray($result);
         $this->assertIsArray($data['params']);
-        $this->assertSame([['name' => 'a', 'value' => 'x'], ['name' => 'b', 'value' => 'empty'], ['name' => 'c', 'value' => 'empty']], $data['params']);
+        $this->assertSame(['version' => 'v1', 'empty_param' => 'empty', 'number' => '42'], $data['params']);
+    }
+
+    public function testParamsWithArrayItemsExtractValue(): void
+    {
+        $result = new Result();
+        $result->id = 'r1';
+        $result->title = 'T';
+        $result->params = [
+            'a' => ['value' => 'x'],
+            'b' => ['value' => null],
+            'c' => ['value' => ''],
+        ];
+
+        $data = $this->serializer->toSpecArray($result);
+        $this->assertIsArray($data['params']);
+        $this->assertSame(['a' => 'x', 'b' => 'empty', 'c' => 'empty'], $data['params']);
     }
 
     public function testParamGroupsWithEmptyValuesBecomeEmptyString(): void


### PR DESCRIPTION
## Summary
- **normalizeParams()** — fixed to return flat `{key: string}` format as required by `result.yaml` schema, instead of wrapping values into `{name, value}` objects
- **Attachment** — generate UUID v4 on construction so `id` is never null in serialized JSON (schema requires `type: string`)
- Bumped version to 2.1.17

## Test plan
- [x] Existing tests pass (117 tests, 248 assertions)
- [x] Old test replaced with two new tests covering both associative string params and array-item params
- [x] Run integration validation with reporters-validator against `result.yaml` schema