### PR TITLE
fix: compare getStatus() as boolean in project/run existence checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "phpunit"
   },
-  "version": "2.1.18",
+  "version": "2.1.19",
   "config": {
     "platform": {
       "php": "8.0"

--- a/src/Client/ApiClientV1.php
+++ b/src/Client/ApiClientV1.php
@@ -96,7 +96,7 @@ class ApiClientV1 implements ClientInterface
             $this->logger->debug('Check project exist: ' . $code);
             $projectsApi = new ProjectsApi($this->client, $this->clientConfig);
             $project = $projectsApi->getProject($code);
-            $result = $project->getStatus() === 200;
+            $result = $project->getStatus() === true;
             if (!$result) {
                 $this->logger->debug('Project not found: ' . $code);
                 return false;
@@ -185,7 +185,7 @@ class ApiClientV1 implements ClientInterface
             $this->logger->debug('Check test run exist: ' . $runId);
             $runApi = new RunsApi($this->client, $this->clientConfig);
             $run = $runApi->getRun($code, $runId);
-            $result = $run->getStatus() === 200;
+            $result = $run->getStatus() === true;
             if (!$result) {
                 $this->logger->debug('Test run not found: ' . $runId);
                 return false;


### PR DESCRIPTION
## Summary
- `ApiClientV1::isTestRunExist()` and `isProjectExist()` called `$response->getStatus()` and compared the result to `200`.
- For `RunResponse` / `ProjectResponse`, `getStatus()` returns the JSON success flag (`bool|null`) from the Qase API envelope, not an HTTP status code.
- The comparison was therefore always false, so both methods reported existing resources as missing and the reporter emitted a spurious \"Run with id X not found\" / \"Project not found\" error for every pre-created id the user passed via config.
- Reproduced against project DEVX on qase.io by pre-creating a run via the public API and pointing \`qase.config.json -> testops.run.id\` at it.

## Fix
Compare `getStatus()` to `true` instead of `200`.

## Test plan
- [x] `vendor/bin/phpunit` — 122/122 OK
- [x] Local repro with qase/phpunit-reporter 2.1.10 + pre-created run id: log now shows \"Test run found: N\" instead of \"Test run not found: N\" / \"Failed to start reporter\"

## Release
Will need a patch release and a bump in downstream reporters (qase-phpunit, qase-codeception, etc.).